### PR TITLE
Configure shopify app with dev url

### DIFF
--- a/shopify.app.scriberrdev.toml
+++ b/shopify.app.scriberrdev.toml
@@ -8,9 +8,17 @@ embedded = true
 [webhooks]
 api_version = "2025-07"
 
+  [[webhooks.subscriptions]]
+  topics = [ "app/uninstalled" ]
+  uri = "/webhooks/app/uninstalled"
+
+  [[webhooks.subscriptions]]
+  topics = [ "app/scopes_update" ]
+  uri = "/webhooks/app/scopes_update"
+
 [access_scopes]
 # Learn more at https://shopify.dev/docs/apps/tools/cli/configuration#access_scopes
-scopes = ""
+scopes = "write_products"
 optional_scopes = [ ]
 use_legacy_install_flow = false
 
@@ -22,4 +30,5 @@ redirect_urls = [
 ]
 
 [build]
+include_config_on_deploy = true
 automatically_update_urls_on_dev = true

--- a/shopify.app.toml
+++ b/shopify.app.toml
@@ -3,7 +3,7 @@
 client_id = "6bce6b128d5d19d33686b60d41c92824"
 name = "scriberr"
 handle = "scriberr"
-application_url = "https://convention-fit-surprise-mechanical.trycloudflare.com"
+application_url = "https://scriberrdev.vercel.app"
 embedded = true
 
 [build]
@@ -26,7 +26,7 @@ api_version = "2025-07"
 scopes = "write_products"
 
 [auth]
-redirect_urls = ["https://convention-fit-surprise-mechanical.trycloudflare.com/auth/callback", "https://convention-fit-surprise-mechanical.trycloudflare.com/auth/shopify/callback", "https://convention-fit-surprise-mechanical.trycloudflare.com/api/auth/callback"]
+redirect_urls = ["https://scriberrdev.vercel.app/auth/callback", "https://scriberrdev.vercel.app/auth/shopify/callback", "https://scriberrdev.vercel.app/api/auth/callback"]
 
 [pos]
 embedded = false


### PR DESCRIPTION
Configure Shopify app to use `scriberrdev.vercel.app` and synchronize environment-specific settings for consistency.

---
<a href="https://cursor.com/background-agent?bcId=bc-b75fa149-b07a-4f72-8985-287387e2782b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b75fa149-b07a-4f72-8985-287387e2782b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

