### PR TITLE
Fix reference error for setSelectedNoteId

### DIFF
--- a/app/routes/app._index.jsx
+++ b/app/routes/app._index.jsx
@@ -264,6 +264,8 @@ export default function Index() {
   
   // Note editing states
   const [editingNoteId, setEditingNoteId] = useState(null);
+  const [selectedNoteId, setSelectedNoteId] = useState(null);
+  const [selectedNote, setSelectedNote] = useState(null);
   const [openNoteMenu, setOpenNoteMenu] = useState(null);
   const [showDeleteNoteConfirm, setShowDeleteNoteConfirm] = useState(null);
   const [showChangeFolderModal, setShowChangeFolderModal] = useState(null);


### PR DESCRIPTION
Add `selectedNoteId` and `selectedNote` state variables to resolve a `ReferenceError` on app launch.

The application was crashing on launch due to `ReferenceError: setSelectedNoteId is not defined` because `setSelectedNoteId` and `setSelectedNote` functions were called without their corresponding `useState` declarations.

---
<a href="https://cursor.com/background-agent?bcId=bc-37478e07-c90a-4287-811c-b406761cc26c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-37478e07-c90a-4287-811c-b406761cc26c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

