### PR TITLE
Fix tip tap drag handle visibility and alignment

### DIFF
--- a/app/components/AdvancedRTE.jsx
+++ b/app/components/AdvancedRTE.jsx
@@ -869,7 +869,7 @@ const AdvancedRTE = ({ value, onChange, placeholder = "Start writing..." }) => {
             style={{
               minHeight: "400px",
               padding: "16px 20px",
-              paddingLeft: "50px", // Extra padding for drag handle
+              paddingLeft: "70px", // Extra padding for drag handle
               border: "none",
               outline: "none",
               fontSize: "14px",

--- a/app/components/NotionTiptapEditor.css
+++ b/app/components/NotionTiptapEditor.css
@@ -9,6 +9,7 @@
   min-height: 500px;
   display: flex;
   flex-direction: column;
+  position: relative; /* Ensure proper positioning context */
 }
 
 /* Drag Handle Styles */
@@ -73,7 +74,11 @@
 /* Responsive adjustments */
 @media (max-width: 768px) {
   .notion-editor {
-    padding-left: 50px; /* Less padding on mobile */
+    padding-left: 60px; /* Less padding on mobile but still space for drag handle */
+  }
+  
+  .tiptap-drag-handle {
+    left: -50px !important; /* Adjust position for mobile */
   }
 }
 
@@ -96,6 +101,7 @@
 .notion-editor-wrapper {
   flex: 1;
   overflow-y: auto;
+  overflow-x: visible; /* Allow drag handle to extend beyond editor bounds */
   background: #ffffff;
   position: relative;
 }
@@ -103,7 +109,7 @@
 /* Editor Core Styles */
 .notion-editor {
   padding: 40px 60px;
-  padding-left: 70px; /* Extra padding on the left for drag handle */
+  padding-left: 80px; /* Extra padding on the left for drag handle */
   min-height: 100%;
   max-width: 900px;
   margin: 0 auto;
@@ -593,21 +599,27 @@
 }
 
 .tiptap-drag-handle {
-  opacity: 0;
+  opacity: 1; /* Always visible when rendered */
   transition: all 0.15s ease;
   pointer-events: auto;
   user-select: none;
   -webkit-user-select: none;
+  background: rgba(255, 255, 255, 0.8);
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
 .tiptap-drag-handle:hover {
   background: rgba(0, 0, 0, 0.1) !important;
   transform: translateY(-50%) scale(1.1) !important;
+  border-color: rgba(0, 0, 0, 0.2);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
 }
 
 .tiptap-drag-handle:active {
   cursor: grabbing;
   background: rgba(0, 0, 0, 0.15) !important;
+  transform: translateY(-50%) scale(1.05) !important;
 }
 
 /* Dark mode drag handle */

--- a/app/components/TiptapDragHandle.jsx
+++ b/app/components/TiptapDragHandle.jsx
@@ -16,6 +16,21 @@ const TiptapDragHandle = ({ editor }) => {
     const editorElement = editor.view.dom;
     editorRef.current = editorElement;
 
+    // Show drag handle when editor is focused
+    const handleFocus = () => {
+      const pos = editor.state.selection.from;
+      if (pos !== null) {
+        updateDragHandle(pos);
+      }
+    };
+
+    const handleSelectionUpdate = () => {
+      const pos = editor.state.selection.from;
+      if (pos !== null) {
+        updateDragHandle(pos);
+      }
+    };
+
     const updateDragHandle = (pos) => {
       if (!pos) {
         setVisible(false);
@@ -43,11 +58,11 @@ const TiptapDragHandle = ({ editor }) => {
 
       // Calculate proper alignment with text baseline
       const lineHeight = coords.bottom - coords.top;
-      const textBaselineOffset = lineHeight * 0.3; // Adjust for text baseline
+      const textBaselineOffset = lineHeight * 0.2; // Better alignment with text baseline
       
       setPosition({
         top: coords.top - editorRect.top + textBaselineOffset,
-        left: -40 // Position outside the editor content area
+        left: -60 // Position outside the editor content area, accounting for editor padding
       });
       setVisible(true);
 
@@ -75,6 +90,14 @@ const TiptapDragHandle = ({ editor }) => {
       }
     };
 
+    const handleMouseEnter = () => {
+      // Show drag handle when entering editor area
+      const pos = editor.state.selection.from;
+      if (pos !== null) {
+        updateDragHandle(pos);
+      }
+    };
+
     const handleMouseLeave = () => {
       setVisible(false);
       setHoveredNode(null);
@@ -83,10 +106,18 @@ const TiptapDragHandle = ({ editor }) => {
     // Add event listeners
     editorElement.addEventListener('mousemove', handleMouseMove);
     editorElement.addEventListener('mouseleave', handleMouseLeave);
+    editorElement.addEventListener('mouseenter', handleMouseEnter);
+    editorElement.addEventListener('focus', handleFocus);
+    
+    // Listen for selection changes
+    editor.on('selectionUpdate', handleSelectionUpdate);
 
     return () => {
       editorElement.removeEventListener('mousemove', handleMouseMove);
       editorElement.removeEventListener('mouseleave', handleMouseLeave);
+      editorElement.removeEventListener('mouseenter', handleMouseEnter);
+      editorElement.removeEventListener('focus', handleFocus);
+      editor.off('selectionUpdate', handleSelectionUpdate);
     };
   }, [editor]);
 
@@ -200,11 +231,11 @@ const TiptapDragHandle = ({ editor }) => {
         alignItems: 'center',
         justifyContent: 'center',
         cursor: isDragging ? 'grabbing' : 'grab',
-        opacity: visible ? 1 : 0,
+        opacity: 1, // Always visible when rendered
         background: 'transparent',
         borderRadius: '4px',
         transition: 'all 0.15s ease',
-        zIndex: 10,
+        zIndex: 1000, // Higher z-index to ensure visibility
         transform: 'translateY(-50%)',
         pointerEvents: 'auto',
       }}


### PR DESCRIPTION
Make the TipTap editor drag handle consistently visible and correctly aligned with text blocks.

The drag handle was not visible due to default `opacity: 0` and was misaligned because its `left` positioning did not account for the editor's `padding-left`. This PR adjusts CSS for visibility, updates positioning logic, and adds event listeners to ensure the handle appears reliably and is correctly placed.

---
<a href="https://cursor.com/background-agent?bcId=bc-8ddb2a21-afd6-441e-a898-eb29cd0b29ff">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8ddb2a21-afd6-441e-a898-eb29cd0b29ff">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

