### PR TITLE
Hide column grab handles in fullscreen editor

### DIFF
--- a/app/components/AdvancedRTE.jsx
+++ b/app/components/AdvancedRTE.jsx
@@ -22,7 +22,7 @@ import TiptapDragHandle from './TiptapDragHandle';
 import { createLowlight } from 'lowlight';
 import { Button, Text, Modal, TextField, Card, InlineStack, BlockStack } from '@shopify/polaris';
 
-const AdvancedRTE = ({ value, onChange, placeholder = "Start writing...", isMobileProp = false }) => {
+const AdvancedRTE = ({ value, onChange, placeholder = "Start writing...", isMobileProp = false, onFullscreenChange }) => {
   const [isExpanded, setIsExpanded] = useState(false);
   const [showImageModal, setShowImageModal] = useState(false);
   const [showVideoModal, setShowVideoModal] = useState(false);
@@ -314,7 +314,13 @@ const AdvancedRTE = ({ value, onChange, placeholder = "Start writing...", isMobi
 
 
   const toggleExpanded = () => {
-    setIsExpanded(!isExpanded);
+    const newExpandedState = !isExpanded;
+    setIsExpanded(newExpandedState);
+    // Notify parent component about fullscreen state change
+    if (onFullscreenChange) {
+      console.log('AdvancedRTE: Notifying parent of fullscreen state change:', newExpandedState);
+      onFullscreenChange(newExpandedState);
+    }
   };
 
   if (!editor) {

--- a/app/components/MobileEditorButton.jsx
+++ b/app/components/MobileEditorButton.jsx
@@ -12,7 +12,8 @@ const MobileEditorButton = ({
   autoSaveTime = null,
   editingNoteId = null,
   wasJustSaved = false,
-  isNewlyCreated = false
+  isNewlyCreated = false,
+  onFullscreenChange
 }) => {
   const [showEditorModal, setShowEditorModal] = useState(false);
 
@@ -284,6 +285,7 @@ const MobileEditorButton = ({
               onChange={onChange}
               placeholder={placeholder}
               isMobileProp={true}
+              onFullscreenChange={onFullscreenChange}
             />
           </div>
         </div>

--- a/app/routes/app.dashboard.jsx
+++ b/app/routes/app.dashboard.jsx
@@ -65,7 +65,7 @@ import {
 import { CSS } from '@dnd-kit/utilities';
 
 /* ------------------ SortableColumn Component ------------------ */
-function SortableColumn({ id, children, ...props }) {
+function SortableColumn({ id, children, isEditorFullscreen, ...props }) {
   const {
     attributes,
     listeners,
@@ -93,32 +93,34 @@ function SortableColumn({ id, children, ...props }) {
       {...attributes}
       {...props}
     >
-      {/* Drag handle positioned lower with more space from top */}
-      <div
-        style={{
-          position: 'absolute',
-          top: '8px',
-          left: '8px',
-          zIndex: 10,
-          cursor: 'grab',
-          padding: '6px',
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          width: '28px',
-          height: '28px'
-        }}
-        {...listeners}
-      >
-        <div style={{ 
-          fontSize: "14px", 
-          color: "#6d7175",
-          userSelect: "none",
-          cursor: "grab"
-        }}>
-          ⋮⋮
+      {/* Drag handle positioned lower with more space from top - hidden when editor is fullscreen */}
+      {!isEditorFullscreen && (
+        <div
+          style={{
+            position: 'absolute',
+            top: '8px',
+            left: '8px',
+            zIndex: 10,
+            cursor: 'grab',
+            padding: '6px',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            width: '28px',
+            height: '28px'
+          }}
+          {...listeners}
+        >
+          <div style={{ 
+            fontSize: "14px", 
+            color: "#6d7175",
+            userSelect: "none",
+            cursor: "grab"
+          }}>
+            ⋮⋮
+          </div>
         </div>
-      </div>
+      )}
       {children}
     </div>
   );
@@ -520,6 +522,21 @@ export default function Index() {
     }
     return ['folders', 'notes', 'editor'];
   });
+
+  // State to track if any editor is in fullscreen mode
+  const [isEditorFullscreen, setIsEditorFullscreen] = useState(false);
+
+  // Debug logging for fullscreen state changes
+  useEffect(() => {
+    console.log('Editor fullscreen state changed:', isEditorFullscreen);
+  }, [isEditorFullscreen]);
+
+  // Cleanup effect to reset fullscreen state when component unmounts
+  useEffect(() => {
+    return () => {
+      setIsEditorFullscreen(false);
+    };
+  }, []);
   
   // Ref to hold the current columnOrder for use in event handlers
   const columnOrderRef = useRef(columnOrder);
@@ -3179,6 +3196,7 @@ export default function Index() {
                   <SortableColumn 
                     key="folders"
                     id="folders"
+                    isEditorFullscreen={isEditorFullscreen}
                     style={{ width: "380px", minWidth: "380px", maxWidth: "380px", overflow: "hidden" }}
                   >
           <Card
@@ -3602,6 +3620,7 @@ export default function Index() {
                   <SortableColumn 
                     key="notes"
                     id="notes"
+                    isEditorFullscreen={isEditorFullscreen}
                     style={{ width: "380px", minWidth: "380px", maxWidth: "380px", overflow: "hidden" }}
                   >
           <Card style={{ flex: "1", display: "flex", flexDirection: "column", backgroundColor: "#fff", height: "100%", minHeight: "100%", padding: "0", margin: "0", borderRadius: "8px", boxShadow: "0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06)", border: "1px solid #e1e3e5" }}>
@@ -3853,6 +3872,7 @@ export default function Index() {
                   <SortableColumn 
                     key="editor"
                     id="editor"
+                    isEditorFullscreen={isEditorFullscreen}
                     style={{ 
                       ...(collapsedColumns.folders && collapsedColumns.notes ? {
                         flex: "1",
@@ -4109,12 +4129,14 @@ export default function Index() {
                       editingNoteId={editingNoteId}
                       wasJustSaved={wasJustSaved}
                       isNewlyCreated={isNewlyCreated}
+                      onFullscreenChange={setIsEditorFullscreen}
                     />
                   ) : (
                     <AdvancedRTE
                       value={body}
                       onChange={setBody}
                       placeholder="Type your note here..."
+                      onFullscreenChange={setIsEditorFullscreen}
                     />
                   )}
                 </div>
@@ -6256,12 +6278,14 @@ export default function Index() {
                       editingNoteId={editingNoteId}
                       wasJustSaved={wasJustSaved}
                       isNewlyCreated={isNewlyCreated}
+                      onFullscreenChange={setIsEditorFullscreen}
                     />
                   ) : (
                     <AdvancedRTE
                       value={body}
                       onChange={setBody}
                       placeholder="Type your note here..."
+                      onFullscreenChange={setIsEditorFullscreen}
                     />
                   )}
                 </div>


### PR DESCRIPTION
Hide column drag handles when the text editor is in fullscreen mode to prevent accidental column rearrangement.

---
<a href="https://cursor.com/background-agent?bcId=bc-8d1cabd7-38b5-4c26-883f-e444e2c29d48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8d1cabd7-38b5-4c26-883f-e444e2c29d48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

