### PR TITLE
Style folder display in mobile note editor

### DIFF
--- a/app/routes/app._index.jsx
+++ b/app/routes/app._index.jsx
@@ -3107,10 +3107,24 @@ export default function Index() {
                   }}>
                     {folderId ? (
                       <>
-                        <span style={{ fontWeight: "500" }}>
+                        {/* Blue pill for folder name on mobile */}
+                        <div style={{
+                          padding: '4px 12px',
+                          borderRadius: '16px',
+                          backgroundColor: '#e3f2fd',
+                          border: '1px solid #007bff',
+                          color: '#007bff',
+                          fontSize: '12px',
+                          fontWeight: '600',
+                          textAlign: 'center',
+                          whiteSpace: 'nowrap',
+                          display: 'flex',
+                          alignItems: 'center',
+                          gap: '6px'
+                        }}>
+                          <i className="far fa-folder" style={{ fontSize: '12px' }}></i>
                           {folders.find(f => f.id === folderId)?.name}
-                        </span>
-                        <span>/</span>
+                        </div>
                         <span style={{ fontWeight: "600", color: "#202223" }}>
                           {title || "(untitled)"}
                         </span>


### PR DESCRIPTION
Update the mobile note editor's folder display to a blue pill style for visual consistency and a cleaner look.

---
<a href="https://cursor.com/background-agent?bcId=bc-9744ab34-4a2e-400d-a792-a8b77876182f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9744ab34-4a2e-400d-a792-a8b77876182f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

