### PR TITLE
Update tiptap line height extension

### DIFF
--- a/app/components/AdvancedRTE.jsx
+++ b/app/components/AdvancedRTE.jsx
@@ -44,7 +44,8 @@ import {
   CollectionIcon,
   DiscountIcon,
   OrderDraftIcon,
-  ProfileIcon
+  ProfileIcon,
+  MeasurementSizeIcon
 } from '@shopify/polaris-icons';
 
 // Simple icon component using emoji/text since many Polaris icons don't exist
@@ -59,7 +60,7 @@ const TextIcon = ({ icon }) => {
     image: '🖼️',
     video: '📹',
     text: '¶',
-    lineHeight: '📏',
+    lineHeight: <MeasurementSizeIcon />,
     bulletList: '•',
     numberedList: '1.',
     checkbox: '☑',
@@ -2087,6 +2088,20 @@ const AdvancedRTE = ({ value, onChange, placeholder = "Start writing...", isMobi
                   content: '2.0',
                   onAction: () => {
                     editor.chain().focus().setLineHeight('2.0').run();
+                    setShowLineHeightPopover(false);
+                  }
+                },
+                {
+                  content: '4.0',
+                  onAction: () => {
+                    editor.chain().focus().setLineHeight('4.0').run();
+                    setShowLineHeightPopover(false);
+                  }
+                },
+                {
+                  content: '4.5',
+                  onAction: () => {
+                    editor.chain().focus().setLineHeight('4.5').run();
                     setShowLineHeightPopover(false);
                   }
                 },


### PR DESCRIPTION
Add 4.0 and 4.5 line height options and update the line height icon to `MeasurementSizeIcon` in the Tiptap editor.

---
<a href="https://cursor.com/background-agent?bcId=bc-f90fed04-fab0-4d08-ae73-5dc8f45640b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f90fed04-fab0-4d08-ae73-5dc8f45640b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

